### PR TITLE
Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,31 @@
->        All items have a `sell_in` value which denotes the number of days we have to sell the item. 
->        All items have a `quality` value which denotes how valuable the item is
->        At the end of each day our system lowers both values for every item by running the `update_quantity` method on each item. 
-> 
->        Once the sell by date has passed, Quality degrades twice as fast
->        The Quality of an item is never negative
->        “Aged Brie” actually increases in Quality the older it gets
->        The Quality of an item is never more than 50
->        “Sulfuras, Hand of Ragnaros”, being a legendary item, never has to be sold or decreases in Quality
->        “Backstage passes to a TAFKAL80ETC concert”, like aged brie, increases in `quality` as it’s `sell_in` value approaches; `quality` increases by 2 when there are 10 days or less and by 3 when there are 5 days or less but `quality` drops to 0 after the concert
-> 
->    We have recently signed a supplier of conjured items. This requires an update to our system:
-> 
->        “Conjured Mana Cake” items degrade in Quality twice as fast as normal items
+# The Gilded Rose
 
+The Gilded Rose is a shop which sells a variety of fantastical items. As such, it needs an equally fantastic inventory management system. Our current system has a variety of rules:
 
-Task: Update the system to be able to handle "conjured" items. Failing specs have been added to help describe this behaviour. 
+* All items have a `sell_in` value which denotes the number of days we have to sell the item.
+* All items have a `quality` value which denotes how valuable the item is.
+* At the end of each day our system runs the `update_quality` method on each item, which lowers both values for every item by 1.
+* Once the `sell_in` date has passed, quality degrades twice as fast.
+* The quality of an item is never negative.
+* The quality of an item is never more than 50.
 
-You may assume that the test coverage is 100%. In otherwords, if the tests pass, the code is perfectly functional. 
+Certain items have special exceptions:
 
-You may make any changes you'd like to the specs, but keep in mind that you shouldn't reduce coverage. 
+* "Aged Brie" actually increases in quality the older it gets.
+* "Sulfuras, Hand of Ragnaros", being a legendary item, never has to be sold or decreases in quality.
+* "Backstage passes to a TAFKAL80ETC concert" are very time-sensitive:
+  * Like "Aged Brie", they increase in `quality` as their `sell_in` value approaches
+  * Its quality increases by 2 when there are 10 days or less
+  * Its quality increases by 3 when there are 5 days or less
+  * Its quality drops to 0 after the concert, once the sell_in date is past
 
+## The challenge
 
+We have recently signed a supplier of conjured items, which requires an
+update to our system. We'd like you to add a "Conjured Mana Cake" item
+which degrades in quality twice as fast as normal items.
 
-
+Failing specs have been added to help describe this behaviour. You may
+assume that the test coverage is 100%. In other words, if the tests pass,
+the code is perfectly functional. You may make any changes you'd like to
+the specs, but keep in mind that you shouldn't reduce coverage.

--- a/ruby/gilded_rose.rb
+++ b/ruby/gilded_rose.rb
@@ -62,7 +62,7 @@ class Item
     @quality = quality
   end
 
-  def to_s()
+  def to_s
     "#{@name}, #{@sell_in}, #{@quality}"
   end
 end


### PR DESCRIPTION
The existing README had most of the useful text in a \<pre\> block which wasn't word-wrapped, so it was a bastard to read, and wasn't very well-explained to boot. I've updated and reformatted the text.